### PR TITLE
additions to the hanami layers API

### DIFF
--- a/london_clojurians_april_2024/src/notebooks/hana.clj
+++ b/london_clojurians_april_2024/src/notebooks/hana.clj
@@ -1,4 +1,4 @@
-(ns london-clojurians-april-2024.hana
+(ns notebooks.hana
   (:require [scicloj.kindly.v4.kind :as kind]
             [scicloj.noj.v1.paths :as paths]
             [scicloj.tempfiles.api :as tempfiles]
@@ -27,7 +27,7 @@
     m))
 
 (defn xform [{:as context
-              :keys [template args]}]
+              :keys [template args stat]}]
   (let [dataset (:metamorph/data context)]
     (-> template
         (hc/xform args)
@@ -61,9 +61,9 @@
 (def view-base (svg-rendered ht/view-base))
 (def point-chart (svg-rendered ht/point-chart))
 (def line-chart (svg-rendered ht/line-chart))
+
 (def point-layer ht/point-layer)
 (def line-layer ht/line-layer)
-
 
 (defn plot
   ([dataset args]
@@ -94,6 +94,14 @@
            :args args})))))
 
 
+(def layer-point
+  (fn [context args]
+    (layer context point-layer args)))
+
+(def layer-line
+  (fn [context args]
+    (layer context line-layer args)))
+
 (delay
   (-> (toydata/iris-ds)
       (plot point-chart
@@ -104,12 +112,12 @@
   (-> (toydata/iris-ds)
       (plot {:TITLE "dummy"
              :MCOLOR "green"})
-      (layer point-layer
-             {:X :sepal_width
-              :Y :sepal_length
-              :MSIZE 100})
-      (layer line-layer
-             {:X :sepal_width
-              :Y :sepal_length
-              :MSIZE 4
-              :MCOLOR "brown"})))
+      (layer-point
+       {:X :sepal_width
+        :Y :sepal_length
+        :MSIZE 100})
+      (layer-line
+       {:X :sepal_width
+        :Y :sepal_length
+        :MSIZE 4
+        :MCOLOR "brown"})))

--- a/london_clojurians_april_2024/src/notebooks/hana.clj
+++ b/london_clojurians_april_2024/src/notebooks/hana.clj
@@ -100,13 +100,17 @@
            :args args})))))
 
 
-(def layer-point
-  (fn [context args]
-    (layer context point-layer args)))
+(defn layer-point
+  ([context]
+   (layer-point context {}))
+  ([context args]
+   (layer context point-layer args)))
 
-(def layer-line
-  (fn [context args]
-    (layer context line-layer args)))
+(defn layer-line
+  ([context]
+   (layer-line context {}))
+  ([context args]
+   (layer context line-layer args)))
 
 (def linreg-stat
   (fn [{:as context
@@ -121,12 +125,14 @@
                                  tc/dataset
                                  (tc/map-columns Y [X] model))))))
 
-(def layer-linreg
-  (fn [context args]
-    (layer context
-           line-layer
-           (merge {:hana/stat linreg-stat}
-                  args))))
+(defn layer-linreg
+  ([context]
+   (layer-linreg context {}))
+  ([context args]
+   (layer context
+          line-layer
+          (merge {:hana/stat linreg-stat}
+                 args))))
 
 (delay
   (-> (toydata/iris-ds)
@@ -138,8 +144,8 @@
   (-> (toydata/iris-ds)
       (plot {:X :sepal_width
              :Y :sepal_length})
-      (layer-point {})
-      (layer-linreg {})))
+      layer-point
+      layer-linreg))
 
 (delay
   (-> (toydata/iris-ds)

--- a/london_clojurians_april_2024/src/notebooks/prepared.clj
+++ b/london_clojurians_april_2024/src/notebooks/prepared.clj
@@ -67,6 +67,21 @@
                       :MSIZE 1})
     (hana/layer-line {:Y :hardcover-prediction}))
 
+
+(-> book-sales
+    ;; they're already sorted, but just to be sure
+    (tc/order-by :date :asc)
+    (tc/add-column :time (range (tc/row-count book-sales)))
+    (hana/plot {:X :time
+                :Y :hardcover
+                :YSCALE {:zero false}
+                :TITLE "Time plot of book sales"})
+    (hana/layer-point{:MCOLOR "black"})
+    (hana/layer-line {:MCOLOR "grey"
+                      :MSIZE 1})
+    hana/layer-linreg)
+
+
 ;; Lag
 
 (-> book-sales
@@ -105,9 +120,24 @@
                 :XSCALE {:zero false}
                 :WIDTH 400
                 :TITLE "Lag plot of book sales"})
-    ( hana/layer-point {:Y :hardcover
-                        :MCOLOR "black"})
+    (hana/layer-point {:Y :hardcover
+                       :MCOLOR "black"})
     (hana/layer-line {:Y :hardcover-prediction}))
+
+
+(-> book-sales
+    (ds-rolling/rolling {:window-type :fixed
+                         :window-size (inc 1)
+                         :relative-window-position :left}
+                        {:lag (ds-rolling/first :hardcover)})
+    (hana/plot {:X :lag
+                :Y :hardcover
+                :YSCALE {:zero false}
+                :XSCALE {:zero false}
+                :WIDTH 400
+                :TITLE "Lag plot of book sales"})
+    (hana/layer-point {:MCOLOR "black"})
+    hana/layer-linreg)
 
 
 ;; There are two kinds of features unique to time series: time-step features and lag features.

--- a/london_clojurians_april_2024/src/notebooks/prepared.clj
+++ b/london_clojurians_april_2024/src/notebooks/prepared.clj
@@ -17,7 +17,7 @@
    [tech.v3.dataset.rolling :as ds-rolling]
    [tech.v3.datatype.rolling :as dtype-rolling]
    [util :as util]
-   [london-clojurians-april-2024.hana :as hana]))
+   [notebooks.hana :as hana]))
 
 (def book-sales
   (tc/dataset "data/book-sales.csv" {:key-fn (comp keyword str/lower-case)}))
@@ -60,12 +60,12 @@
     (hana/plot {:X :time
                 :YSCALE {:zero false}
                 :TITLE "Time plot of book sales"})
-    (hana/layer hana/point-layer {:Y :hardcover
-                                  :MCOLOR "black"})
-    (hana/layer hana/line-layer {:Y :hardcover
-                                 :MCOLOR "grey"
-                                 :MSIZE 1})
-    (hana/layer hana/line-layer {:Y :hardcover-prediction}))
+    (hana/layer-point{:Y :hardcover
+                      :MCOLOR "black"})
+    (hana/layer-line {:Y :hardcover
+                      :MCOLOR "grey"
+                      :MSIZE 1})
+    (hana/layer-line {:Y :hardcover-prediction}))
 
 ;; Lag
 
@@ -105,9 +105,9 @@
                 :XSCALE {:zero false}
                 :WIDTH 400
                 :TITLE "Lag plot of book sales"})
-    (hana/layer hana/point-layer {:Y :hardcover
-                                  :MCOLOR "black"})
-    (hana/layer hana/line-layer {:Y :hardcover-prediction}))
+    ( hana/layer-point {:Y :hardcover
+                        :MCOLOR "black"})
+    (hana/layer-line {:Y :hardcover-prediction}))
 
 
 ;; There are two kinds of features unique to time series: time-step features and lag features.
@@ -163,13 +163,13 @@
                 :YSCALE {:zero false}
                 :XSCALE {:zero false}
                 :TITLE "Time plot of tunnel traffic"})
-    (hana/layer hana/point-layer {:Y :numvehicles
-                                  :MCOLOR "black"
-                                  :MSIZE 15})
-    (hana/layer hana/line-layer {:Y :numvehicles
-                                 :MCOLOR "grey"
-                                 :MSIZE 1})
-    (hana/layer hana/line-layer {:Y :numvehicles-prediction}))
+    ( hana/layer-point {:Y :numvehicles
+                        :MCOLOR "black"
+                        :MSIZE 15})
+    (hana/layer-line {:Y :numvehicles
+                      :MCOLOR "grey"
+                      :MSIZE 1})
+    (hana/layer-line {:Y :numvehicles-prediction}))
 
 
 (-> tunnel
@@ -240,10 +240,10 @@
                 :XTYPE :temporal
                 :YSCALE {:zero false}
                 :TITLE "Tunnel traffic - 365 day moving average"})
-    (hana/layer hana/point-layer {:Y :numvehicles
-                                  :MCOLOR "black"
-                                  :MSIZE 15})
-    (hana/layer hana/line-layer {:Y :average}))
+    ( hana/layer-point {:Y :numvehicles
+                        :MCOLOR "black"
+                        :MSIZE 15})
+    (hana/layer-line {:Y :average}))
 
 
 ;; (let [signal [-1 2 4 99 4 2 -1]
@@ -325,12 +325,12 @@
                 :HEIGHT 500
                 :WIDTH 1200
                 :TITLE "Tunnel traffic - 365 day moving average"})
-    (hana/layer hana/point-layer {:Y :numvehicles
-                                  :MCOLOR "black"
-                                  :MSIZE 15})
-    (hana/layer hana/line-layer {:Y :numvehicles-prediction
+    ( hana/layer-point {:Y :numvehicles
+                                   :MCOLOR "black"
+                                   :MSIZE 15})
+    (hana/layer-line {:Y :numvehicles-prediction
                                  :MCOLOR "orange"})
-    (hana/layer hana/line-layer {:Y :average}))
+    (hana/layer-line {:Y :average}))
 
 
 
@@ -375,14 +375,14 @@
   (-> with-time-dummy
       (tc/map-columns :numvehicles-prediction [:time] regressor)
       (hana/plot {:X :day
-                 :XTYPE :temporal
-                 :YSCALE {:zero false}
-                 :WIDTH 1000
-                 :TITLE "Tunnel traffic - dtype next regressor"})
-      (hana/layer hana/point-layer {:Y :numvehicles
-                                    :MCOLOR "black"
-                                    :MSIZE 15})
-      (hana/layer hana/line-layer {:Y :numvehicles-prediction})))
+                  :XTYPE :temporal
+                  :YSCALE {:zero false}
+                  :WIDTH 1000
+                  :TITLE "Tunnel traffic - dtype next regressor"})
+      ( hana/layer-point {:Y :numvehicles
+                                     :MCOLOR "black"
+                                     :MSIZE 15})
+      (hana/layer-line {:Y :numvehicles-prediction})))
 
 
 ;; out of sample
@@ -442,11 +442,11 @@
                   :YSCALE {:zero false}
                   :WIDTH 1000
                   :TITLE "Tunnel traffic - 365 day moving average"})
-      (hana/layer hana/point-layer {:Y :numvehicles
-                                    :MCOLOR "black"
-                                    :MSIZE 15})
-      (hana/layer hana/line-layer {:Y :numvehicles-prediction
-                                   :COLOR {:field :relative-time}})))
+      ( hana/layer-point {:Y :numvehicles
+                          :MCOLOR "black"
+                          :MSIZE 15})
+      (hana/layer-line {:Y :numvehicles-prediction
+                        :COLOR {:field :relative-time}})))
 
 ;; Date dt = new Date ();
 ;; DateTime dtOrg = new DateTime (dt);


### PR DESCRIPTION
* added per-layer convenience functions (e.g., `layer-point` to add a point layer, similar to ggplot's `geom_point`)

* added a `layer-smooth` layer function that adds a line based on linear predictions

