### PR TITLE
hana/layer-smooth: using dtype-next rather than smile in the case of simple regression

### DIFF
--- a/london_clojurians_april_2024/src/notebooks/hana.clj
+++ b/london_clojurians_april_2024/src/notebooks/hana.clj
@@ -168,8 +168,20 @@
   (-> (toydata/iris-ds)
       (plot {:X :sepal_width
              :Y :sepal_length})
+      layer-point))
+
+(delay
+  (-> (toydata/iris-ds)
+      (plot {:X :sepal_width
+             :Y :sepal_length})
       layer-point
       layer-smooth))
+
+(delay
+  (-> (toydata/iris-ds)
+      (plot {:X :sepal_width
+             :Y :sepal_length})
+      layer-point))
 
 (delay
   (-> (toydata/iris-ds)

--- a/london_clojurians_april_2024/src/notebooks/prepared.clj
+++ b/london_clojurians_april_2024/src/notebooks/prepared.clj
@@ -453,6 +453,19 @@
       (hana/layer-line {:Y :numvehicles-prediction})))
 
 
+(let [with-time-dummy (-> tunnel
+                          (tc/add-column :time (range (tc/row-count tunnel))))]
+  (-> with-time-dummy
+      (hana/plot {:X :day
+                  :Y :numvehicles
+                  :XTYPE :temporal
+                  :YSCALE {:zero false}
+                  :WIDTH 1000
+                  :TITLE "Tunnel traffic - dtype next regressor"})
+      (hana/layer-point {:MCOLOR "black"
+                         :MSIZE 15})
+      (hana/layer-smooth {:X-predictors [:time]})))
+
 ;; out of sample
 
 (let [ds-with-prediction (-> tunnel


### PR DESCRIPTION
This small PR makes sure to use dtype-next's simple linear regression when possible in `hana/layer-smooth` (here, 'when possible' means linear regression with one predictor variable, which is currently the use-case in this project).